### PR TITLE
Add Baltic languages section to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ More tricks and techniques can be found on [this famous blog](https://somerandom
     - [Identify Cyrillic languages](#identify-cyrillic-languages)
     - [How to say "street"](#how-to-say-street)
     - [Nordic languages](#nordic-languages)
+    - [Baltic languages](#baltic-languages)
   - [Road signs](#road-signs)
     - [USA](#usa)
     - [USA vs Canada](#usa-vs-canada)


### PR DESCRIPTION
I noticed that the "Baltic languages" section isn't contained within the "Languages" table of contents, it might make quick moving through the document difficult sometimes, so I decided to fix it.